### PR TITLE
sfos: Include configuration from default.pa.d directory.

### DIFF
--- a/src/daemon/default.pa.in
+++ b/src/daemon/default.pa.in
@@ -173,3 +173,9 @@ load-module module-filter-apply
 ### Make some devices default
 #set-default-sink output
 #set-default-source input
+
+### Allow including a default.pa.d directory, which if present, can be used
+### for additional configuration snippets.
+### Note that those snippet files must have a .pa file extension.
+.nofail
+.include /etc/pulse/default.pa.d


### PR DESCRIPTION
When using default.pa allow for easy extending of configuration.