### PR TITLE
Increase resampler quality.

### DIFF
--- a/rpm/50-sfos.daemon.conf
+++ b/rpm/50-sfos.daemon.conf
@@ -8,22 +8,9 @@
 # so this change should be eventually dropped.
 exit-idle-time = -1
 
-# speex-float-x is arguably too heavy resampler to be the default.
-# Ubuntu, for example, patches this to speex-float-2. Mer is targeted
-# at mobile devices, and speex-float-2 may still be a bit too heavy
-# for that purpose. Ideally the default resampler would be decided by
-# hardware adaptations, but for now we patch this in Mer.
-#
-# Why ffmpeg, why not e.g. speex-fixed-1? I don't know, I'm not aware
-# of the history of that decision. If you think something else would
-# be better, feel free to change this (and document the rationale
-# here).
-#
-# Changed from ffmpeg to speex-fixed-2 due to ffmpeg producing broken
-# audio data in some cases (mono samples). No good other rationale
-# for choosing the resampling method as of yet. Benchmarking different
-# resamplers would be a good starting point to decide properly.
-resample-method = speex-fixed-2
+# Modern devices are fast enough to up the resampler quality a bit.
+# In really low-end devices it still might make sense to have speex-fixed-2.
+resample-method = speex-fixed-4
 
 # Enable flat volumes
 flat-volumes = yes


### PR DESCRIPTION
Modern devices are fast enough to up the resampler quality a bit. In really low-end devices it still might make sense to have speex-fixed-2.
